### PR TITLE
7.x backwards compatibility updates

### DIFF
--- a/modules/addons/jetpack/jetpack.php
+++ b/modules/addons/jetpack/jetpack.php
@@ -65,13 +65,12 @@ function jetpack_activate()
         }
     }
 
-    $jetpack_product_group = Capsule::table('tblproductgroups')->where(['name' => 'Jetpack','slug' => 'jetpack'])->first();
+    $jetpack_product_group = Capsule::table('tblproductgroups')->where(['name' => 'Jetpack'])->first();
     if (is_null($jetpack_product_group)) {
         try {
             Capsule::table('tblproductgroups')->insert(
                 [
                     'name' => 'Jetpack',
-                    'slug' => 'jetpack',
                     'headline' => 'Jetpack Products',
                     'hidden' => 1,
                     'created_at' => date('Y-m-d H:i:s'),

--- a/modules/addons/jetpack/lib/Jetpack/AdminController.php
+++ b/modules/addons/jetpack/lib/Jetpack/AdminController.php
@@ -103,7 +103,7 @@ class AdminController
     public function createWHMCSProduct($product_name, $config1, $config2)
     {
         jetpack_activate();
-        $product_group = Capsule::table('tblproductgroups')->where(['name' => 'Jetpack', 'slug' => 'jetpack'])->first();
+        $product_group = Capsule::table('tblproductgroups')->where(['name' => 'Jetpack'])->first();
         if (!$product_group) {
             return false;
         }

--- a/modules/addons/jetpack/lib/Jetpack/AdminViews.php
+++ b/modules/addons/jetpack/lib/Jetpack/AdminViews.php
@@ -96,18 +96,24 @@ class AdminViews {
     {
         $products = Capsule::table('tblproducts')->where('servertype', 'jetpack')->select(['id','name'])->get();
         $product_addons = Capsule::table('tbladdons')->where('module', 'jetpack')->select(['id','name'])->get();
+
+        if (is_a($products, 'Illuminate\Database\Eloquent\Collection')) {
+            $products = $products->toArray();
+            $product_addons = $product_addons->toArray();
+        }
+
         $table_row_products = '';
         $table_row_product_addons = '';
 
-        if ($products->isEmpty() && $product_addons->isEmpty()) {
+        if (empty($products) && empty($product_addons)) {
             $table_row_products = '<tr><td colspan ="3"; style="text-align: center";> No Jetpack products or product addons found. Add some below.</td></tr>';
         }
-        if (!$products->isEmpty()) {
+        if (!empty($products)) {
             foreach ($products as $product) {
                 $table_row_products .= "<tr><td><a href=configproducts.php?action=edit&id=$product->id>$product->name</a></td><td>Product</td></tr>";
             }
         }
-        if (!$product_addons->isEmpty()) {
+        if (!empty($product_addons)) {
             foreach ($product_addons as $product_addon) {
                 $table_row_products .= "<tr><td><a href=configaddons.php?action=manage&id=$product_addon->id>$product_addon->name</a></td><td>Product Addon</td></tr>";
             }


### PR DESCRIPTION
Update addon module activation to not use or insert a slug when creating product groups as they are not supported in 7.x. Also update the Admin views to default to arrays for collections.