### PR TITLE
Added compatibility fixes for PHP 7.2 and corrected spelling errors

### DIFF
--- a/modules/addons/jetpack/jetpack.php
+++ b/modules/addons/jetpack/jetpack.php
@@ -38,7 +38,6 @@ function jetpack_config()
  * Activation Options. Creates a table to store licenses if it doesn't already exist and create
  * the Jetpack Product group also if it does not already exist.
  *
- *
  * @return void
  */
 function jetpack_activate()

--- a/modules/addons/jetpack/lib/Jetpack/AdminController.php
+++ b/modules/addons/jetpack/lib/Jetpack/AdminController.php
@@ -58,7 +58,7 @@ class AdminController
     }
 
     /**
-     * Add a Jetpack Product with required configurations fields to a hosting partners whmcs product
+     * Add a Jetpack Product with required configurations fields to a hosting partners WHMCS product
      * list.
      *
      * @param array $params Module configuration parameters.
@@ -176,7 +176,7 @@ class AdminController
     }
 
     /**
-     * Format product name to remove undersocres and capitalize.
+     * Format product name to remove underscores and capitalize.
      *
      * @param string $product_name
      * @return string Formatted product name string.

--- a/modules/addons/jetpack/lib/Jetpack/AdminViews.php
+++ b/modules/addons/jetpack/lib/Jetpack/AdminViews.php
@@ -5,7 +5,7 @@ namespace Jetpack;
 use WHMCS\Database\Capsule;
 
 /**
- * Maintains functions used to create views for the whmcs addon module.
+ * Maintains functions used to create views for the WHMCS addon module.
  */
 class AdminViews {
 
@@ -35,13 +35,12 @@ class AdminViews {
     public $partner_api_token;
 
     /**
-     *
-     * @param array $params whmcs module parameters.
+     * @param array $params WHMCS module parameters.
      */
     public function __construct($params)
     {
-        $this->module_link    = $params['modulelink'];
-        $this->partner_api_token     = $params['api_token'];
+        $this->module_link = $params['modulelink'];
+        $this->partner_api_token = $params['api_token'];
     }
 
     public function index()
@@ -86,7 +85,7 @@ class AdminViews {
                     <div class="{$type_div[$type]}"><strong>
                         <span class="title">{$title}!</span>
                     </strong><br>{$message}</div>
-        HTML;
+HTML;
     }
 
     /**
@@ -134,7 +133,7 @@ class AdminViews {
         </table>
         <br>
         <hr>
-        HTML;
+HTML;
     }
 
     /**
@@ -175,7 +174,7 @@ class AdminViews {
             </div>
         </form>
         <hr>
-        HTML;
+HTML;
     }
 
     /**
@@ -202,6 +201,6 @@ class AdminViews {
             </div>
         </form>
         <hr>
-        HTML;
+HTML;
     }
 }

--- a/modules/servers/jetpack/lib/Jetpack/JetpackLicenseAPIManager.php
+++ b/modules/servers/jetpack/lib/Jetpack/JetpackLicenseAPIManager.php
@@ -86,7 +86,7 @@ class JetpackLicenseAPIManager
     }
 
     /**
-     * Revoke a liencse for a Jetpack Product
+     * Revoke a license for a Jetpack Product
      *
      * @param string $license license key
      * @return Response
@@ -100,14 +100,14 @@ class JetpackLicenseAPIManager
     }
 
     /**
-     * Revoke a liencse for a Jetpack Product
+     * Revoke a license for a Jetpack Product
      *
      * @param string $license license key
      * @return Response
      */
     public function getJetpackProducts() {
         $response = $this->client->get(
-            self::PRODUCTS_API_URI,
+            self::PRODUCTS_API_URI
         );
         return $response;
     }

--- a/modules/servers/jetpack/lib/Jetpack/JetpackLicenseManager.php
+++ b/modules/servers/jetpack/lib/Jetpack/JetpackLicenseManager.php
@@ -7,42 +7,42 @@ use WHMCS\Database\Capsule;
 class JetpackLicenseManager
 {
     /**
-     * Save a new License for a product prov isioned through the Jetpack Licensing API on a WHMCS order
+     * Save a new License for a product provisioned through the Jetpack Licensing API on a WHMCS order
      *
      * @param integer $order_id THe WHMCS order id.
      * @param integer $product_id The WHMCS product id.
      * @param string $license_key The Jetpack product license.
-     * @param string $licnese_issued_at The date the license was issued at supplied by the Jetpack Licensing API.
+     * @param string $license_issued_at The date the license was issued at supplied by the Jetpack Licensing API.
      * @return void
      */
-    public function saveLicense(int $order_id, int $product_id, string $license_key, string $licnese_issued_at)
+    public function saveLicense(int $order_id, int $product_id, string $license_key, string $license_issued_at)
     {
         Capsule::table('jetpack_product_licenses')->insert(
             [
                 'order_id' => $order_id,
                 'product_id' => $product_id,
                 'license_key' => $license_key,
-                'issued_at' => $licnese_issued_at,
+                'issued_at' => $license_issued_at,
             ]
         );
     }
 
     /**
      * Update a license record with a revoked at time provided by the Jetpack licensing API when
-     * a license i reovked
+     * a license is revoked
      *
-     * @param string $licnese_id The license id to update
+     * @param string $license_id The license id to update
      * @param string $revoked_at The time supplied by the API when the license was revoked
      * @return void
      */
-    public function revokeLicense(string $licnese_id, string $revoked_at) {
+    public function revokeLicense(string $license_id, string $revoked_at) {
         Capsule::table('jetpack_product_licenses')
-        ->where([ 'id' => $licnese_id])
+        ->where([ 'id' => $license_id])
         ->update(['revoked_at' => $revoked_at]);
     }
 
     /**
-     * Find an active licnese for a WHMCS order for a jetpack prdouct
+     * Find an active license for a WHMCS order for a Jetpack product
      *
      * @param array WHMCS $params
      * @return StdObject
@@ -61,9 +61,9 @@ class JetpackLicenseManager
     }
 
     /**
-     * Get the license key for an active license for a jetpack product
+     * Get the license key for an active license for a Jetpack product
      *
-     * @return stirng The license key or "No License Key Found"
+     * @return string The license key or "No License Key Found"
      */
     public function getLicenseKey(int $order_id, int $product_id)
     {


### PR DESCRIPTION
Heredoc syntax was relaxed in PHP 7.3 but remains rigid in PHP 7.2. Indentation on the closing Heredoc marker will result in a parse error in PHP 7.2. PHP 7.3 also allows trailing commas in function calls but PHP 7.2 does not and will also result in a parse error. 